### PR TITLE
speed optimization

### DIFF
--- a/src/calc_np.cpp
+++ b/src/calc_np.cpp
@@ -4,7 +4,7 @@ using namespace Rcpp;
 
 // [[Rcpp::export]]
 
-double fcalc_np(double c_i, NumericVector c_j) {
+double fcalc_np(double c_i, NumericVector &c_j) {
   //initialize c_j_sum
   double c_j_sum = 0;
   int n = c_j.size();


### PR DESCRIPTION
there's probably more speed optimization to be done, but this is a start. `calc_np_all2` ends up faster than `calc_np_all` for me (`bench::mark` results below).

```
> bench::mark(calc_np_all(exp = expr, g = g), calc_np_all2(exp = expr, g = g), iterations = 25)
# A tibble: 2 x 13
  expression                           min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result  
  <bch:expr>                      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>  
1 calc_np_all(exp = expr, g = g)      1.1s    1.13s     0.884     221MB     1.52    25    43      28.3s <dbl [1…
2 calc_np_all2(exp = expr, g = g)  739.6ms 753.78ms     1.32      145MB     1.43    25    27      18.9s <dbl [1…
# … with 3 more variables: memory <list>, time <list>, gc <list>
```